### PR TITLE
ci: migrate `::set-output` command

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Variable-Yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Cache Yarn cache directory
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## CI

- Migrate the [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/?WT.mc_id=DT-MVP-5003831) `::set-output` command to the `GITHUB_OUTPUT` environment variable